### PR TITLE
changing copyright notice back to standard

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -85,9 +85,7 @@
 
     <footer>
       <span class='copyright'>
-          <a rel="license" href="http://creativecommons.org/licenses/by/3.0/deed.en_US">
-              <img alt="Creative Commons License" style="border-width:0" src="//i.creativecommons.org/l/by/3.0/80x15.png" /></a>
-              <span xmlns:dct="http://purl.org/dc/terms/" property="dct:title">CUT Group</span> by <a xmlns:cc="http://creativecommons.org/ns#" href="http://cutgroup.smartchicagoapps.org" property="cc:attributionName" rel="cc:attributionURL">Smart Chicago Collaborative</a> is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/3.0/deed.en_US">Creative Commons Attribution 3.0 Unported License</a>.
+        &copy; 2013 Smart Chicago Collaborative, all rights reserved.
       </span>
     </footer>
 </body>


### PR DESCRIPTION
Drops CC, puts back in standard "all rights reserved" wording.
