### PR TITLE
properly validate mail chimp static segment exports to max 50 char.

### DIFF
--- a/app/models/mailchimp_export.rb
+++ b/app/models/mailchimp_export.rb
@@ -1,6 +1,6 @@
 class MailchimpExport < ActiveRecord::Base
   validates_presence_of :name, :body
-  validates_length_of   :name, :in => 1..40
+  validates_length_of   :name, :in => 1..50
   
   attr_accessor :recipients  # array of email addresses to be added to the segment
   

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -56,4 +56,15 @@ class EventsControllerTest < ActionController::TestCase
     
     assert_response :success
   end
+
+  test "should export event with long name" do
+    MailchimpExport.any_instance.expects(:send_to_mailchimp).returns(true)
+    @event.name = "Lorem ipsum dolor sit amet, consectetur adipisicing elit"
+
+    assert_difference "MailchimpExport.count" do
+      post :export, id: @event, format: :js
+    end
+    
+    assert_response :success    
+  end
 end


### PR DESCRIPTION
This change closes #34.

Mailchimp limits the name of static segments to 50 characters, and we truncate titles to be 50 characters. However, there was some validation code that threw an error if the title was more than 40 characters. This change increases the validation to accept titles up to 50 characters long.
